### PR TITLE
fix: update Dockerfile

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod download
 RUN CGO_ENABLE=0 go build -trimpath -ldflags='-s -w' -o main ./cmd/serve/main.go
 RUN chmod +x main
 
-FROM golang:1.24.0-slim-buillseye AS production
+FROM ubuntu:24.04 AS production
 WORKDIR /work/
 COPY --from=go-build /work/main ./main
 USER ubuntu


### PR DESCRIPTION
## Discription
golang:1.24.0-slim-buillseyeっていうイメージがないらしいので，ubuntuイメージに変更

## Related issue
- #60 